### PR TITLE
remove -j argument for <jsondata> from searchByAttributes help

### DIFF
--- a/G2Command.py
+++ b/G2Command.py
@@ -1286,7 +1286,7 @@ class G2CmdShell(cmd.Cmd, object):
             print(err)
 
     def do_searchByAttributes(self, arg):
-        '\nSearch by attributes:  searchByAttributes -j <jsonData> [-f <flags>]\n'
+        '\nSearch by attributes:  searchByAttributes <jsonData> [-f <flags>]\n'
 
         try:
             args = self.parser.parse_args(['searchByAttributes'] + parse(arg))


### PR DESCRIPTION
# Pull request questions

## Why was change needed

The -j argument is no longer used, the <jsondata> is put immediately after searchByAttributes

